### PR TITLE
Add Line Numbers to G-Code output

### DIFF
--- a/f-engrave.py
+++ b/f-engrave.py
@@ -7768,7 +7768,7 @@ class Application(Frame):
         self.Label_line_numb_ToolTip = ToolTip(
             self.Label_line_numb,
             text="Adds line numbers to the G-Code output. "
-            "The additional data may lead to studdering due "
+            "The additional data may lead to stuttering due "
             "to proccessing speed of some CNC controllers.",
         )
         self.Checkbutton_line_numbers = Checkbutton(gen_settings, text="", anchor=W)

--- a/f-engrave.py
+++ b/f-engrave.py
@@ -576,6 +576,7 @@ class Application(Frame):
         self.no_comments = BooleanVar()
         self.ext_char = BooleanVar()
         self.var_dis = BooleanVar()
+        self.line_numbers = BooleanVar()
         self.useIMGsize = BooleanVar()
         self.plotbox = BooleanVar()
 
@@ -669,6 +670,7 @@ class Application(Frame):
         self.no_comments.set(1)
         self.ext_char.set(0)
         self.var_dis.set(1)
+        self.line_numbers.set(1)
 
         self.clean_P.set(1)
         self.clean_X.set(1)
@@ -1884,6 +1886,7 @@ class Application(Frame):
             arc_fit=self.arc_fit.get(),
             metric=self.units.get() != "in",
             enable_variables=not self.var_dis.get(),
+            line_numbers=self.line_numbers.get()
         )
 
         if config_file or not self.no_comments.get():
@@ -7751,6 +7754,17 @@ class Application(Frame):
             x=xd_entry_L, y=D_Yloc, width=75, height=23
         )
         self.Checkbutton_var_dis.configure(variable=self.var_dis)
+
+        D_Yloc = D_Yloc + D_dY
+        self.Label_var_dis = Label(gen_settings, text="Output Line Numbers")
+        self.Label_var_dis.place(
+            x=xd_label_L, y=D_Yloc, width=w_label, height=21
+        )
+        self.Checkbutton_line_numbers = Checkbutton(gen_settings, text="", anchor=W)
+        self.Checkbutton_line_numbers.place(
+            x=xd_entry_L, y=D_Yloc, width=75, height=23
+        )
+        self.Checkbutton_line_numbers.configure(variable=self.line_numbers)
 
         D_Yloc = D_Yloc + D_dY
         font_entry_width = 215

--- a/f-engrave.py
+++ b/f-engrave.py
@@ -1668,6 +1668,9 @@ class Application(Frame):
             "fengrave_set var_dis     %s " % (int(self.var_dis.get()))
         )
         gcode.append_comment(
+            "fengrave_set line_numbers %s " % (int(self.line_numbers.get()))
+        )
+        gcode.append_comment(
             "fengrave_set ext_char    %s " % (int(self.ext_char.get()))
         )
         gcode.append_comment(
@@ -3833,6 +3836,8 @@ class Application(Frame):
                     )
                 elif "var_dis" in input_code:
                     self.var_dis.set(line[line.find("var_dis") :].split()[1])
+                elif "line_numbers" in input_code:
+                    self.line_numbers.set(line[line.find("line_numbers") :].split()[1])
                 elif "v_depth_lim" in input_code:
                     self.v_depth_lim.set(
                         line[line.find("v_depth_lim") :].split()[1]

--- a/f-engrave.py
+++ b/f-engrave.py
@@ -670,7 +670,7 @@ class Application(Frame):
         self.no_comments.set(1)
         self.ext_char.set(0)
         self.var_dis.set(1)
-        self.line_numbers.set(1)
+        self.line_numbers.set(0)
 
         self.clean_P.set(1)
         self.clean_X.set(1)
@@ -7761,9 +7761,15 @@ class Application(Frame):
         self.Checkbutton_var_dis.configure(variable=self.var_dis)
 
         D_Yloc = D_Yloc + D_dY
-        self.Label_var_dis = Label(gen_settings, text="Output Line Numbers")
-        self.Label_var_dis.place(
+        self.Label_line_numb = Label(gen_settings, text="Output Line Numbers")
+        self.Label_line_numb.place(
             x=xd_label_L, y=D_Yloc, width=w_label, height=21
+        )
+        self.Label_line_numb_ToolTip = ToolTip(
+            self.Label_line_numb,
+            text="Adds line numbers to the G-Code output. "
+            "The additional data may lead to studdering due "
+            "to proccessing speed of some CNC controllers.",
         )
         self.Checkbutton_line_numbers = Checkbutton(gen_settings, text="", anchor=W)
         self.Checkbutton_line_numbers.place(

--- a/gcode.py
+++ b/gcode.py
@@ -28,6 +28,7 @@ class Gcode(list):
         self.lastx = self.lasty = self.lastz = self.lastf = None
         self.feed = None
         self.plane = None
+        self.linenumber = 0
         self.cuts = []
         self.metric = metric
         self.enable_variables = enable_variables
@@ -49,7 +50,7 @@ class Gcode(list):
             assert plane in (Plane.xy, Plane.xz, Plane.yz)
             if plane != self.plane:
                 self.plane = plane
-                self.write('N0 '+"G%d" % plane)
+                self.writeline("G%d" % plane)
 
     # If any 'cut' moves are stored up, send them to the simplification
     # algorithm and actually output them.
@@ -147,7 +148,7 @@ class Gcode(list):
                            Jstring, fstring])
 
         if cmd:
-            self.write('N0 '+cmd)
+            self.writeline(cmd)
 
     def set_feed(self, feed, write_it=False):
         # Set the feed rate to the given value
@@ -157,7 +158,7 @@ class Gcode(list):
         self.feed = FORMAT % self.feed_val
         self.lastf = None
         if write_it:
-            self.write('N0 '+self.feed)
+            self.writeline(self.feed)
             self.lastf = self.feed
 
     def set_z_feed(self, z_feed):
@@ -209,7 +210,7 @@ class Gcode(list):
     def _append_pre_post_amble(self, commands, comment):
         self.append_comment(comment)
         for line in commands.split('|'):
-            self.write('N0 '+line)
+            self.writeline(line)
         self.append_comment("End %s" % (comment))
 
     def append_preamble(self, commands):
@@ -220,15 +221,20 @@ class Gcode(list):
 
     def append_mode(self):
         # G90        ; Sets absolute distance mode
-        self.write('N0 '+'G90 (absolute)')
+        self.writeline('G90 (absolute)')
         # G91.1      ; Sets Incremental Distance Mode for I, J & K arc offsets.
         if (self.arc_fit == "center"):
-            self.write('N0 '+'G91.1')
+            self.writeline('G91.1')
 
     def append_units(self):
         if self.metric:
             # G21 ; sets units to mm
-            self.write('N0 '+'G21 (mm)')
+            self.writeline('G21 (mm)')
         else:
             # G20 ; sets units to inches
-            self.write('N0 '+'G20 (in)')
+            self.writeline('G20 (in)')
+
+    def writeline(self,line):
+        self.linenumber=self.linenumber+1
+        newline = "".join(['N'+str(self.linenumber), ' ',line])
+        self.write(newline)

--- a/gcode.py
+++ b/gcode.py
@@ -49,7 +49,7 @@ class Gcode(list):
             assert plane in (Plane.xy, Plane.xz, Plane.yz)
             if plane != self.plane:
                 self.plane = plane
-                self.write("G%d" % plane)
+                self.write('N0 '+"G%d" % plane)
 
     # If any 'cut' moves are stored up, send them to the simplification
     # algorithm and actually output them.
@@ -147,7 +147,7 @@ class Gcode(list):
                            Jstring, fstring])
 
         if cmd:
-            self.write(cmd)
+            self.write('N0 '+cmd)
 
     def set_feed(self, feed, write_it=False):
         # Set the feed rate to the given value
@@ -157,7 +157,7 @@ class Gcode(list):
         self.feed = FORMAT % self.feed_val
         self.lastf = None
         if write_it:
-            self.write(self.feed)
+            self.write('N0 '+self.feed)
             self.lastf = self.feed
 
     def set_z_feed(self, z_feed):
@@ -209,7 +209,7 @@ class Gcode(list):
     def _append_pre_post_amble(self, commands, comment):
         self.append_comment(comment)
         for line in commands.split('|'):
-            self.write(line)
+            self.write('N0 '+line)
         self.append_comment("End %s" % (comment))
 
     def append_preamble(self, commands):
@@ -220,15 +220,15 @@ class Gcode(list):
 
     def append_mode(self):
         # G90        ; Sets absolute distance mode
-        self.write('G90 (absolute)')
+        self.write('N0 '+'G90 (absolute)')
         # G91.1      ; Sets Incremental Distance Mode for I, J & K arc offsets.
         if (self.arc_fit == "center"):
-            self.write('G91.1')
+            self.write('N0 '+'G91.1')
 
     def append_units(self):
         if self.metric:
             # G21 ; sets units to mm
-            self.write('G21 (mm)')
+            self.write('N0 '+'G21 (mm)')
         else:
             # G20 ; sets units to inches
-            self.write('G20 (in)')
+            self.write('N0 '+'G20 (in)')

--- a/gcode.py
+++ b/gcode.py
@@ -22,7 +22,8 @@ class Gcode(list):
                  tolerance=0.001,
                  arc_fit="none",
                  metric=False,
-                 enable_variables=False):
+                 enable_variables=False,
+                 line_numbers=1):
         list.__init__(self)
 
         self.lastx = self.lasty = self.lastz = self.lastf = None
@@ -32,6 +33,7 @@ class Gcode(list):
         self.cuts = []
         self.metric = metric
         self.enable_variables = enable_variables
+        self.line_numbers = line_numbers
         if self.metric:
             self.dp = 3
             self.dpfeed = 1
@@ -235,6 +237,9 @@ class Gcode(list):
             self.writeline('G20 (in)')
 
     def writeline(self,line):
-        self.linenumber=self.linenumber+1
-        newline = "".join(['N'+str(self.linenumber), ' ',line])
-        self.write(newline)
+        if (self.line_numbers == 1):
+            self.linenumber=self.linenumber+1
+            newline = "".join(['N'+str(self.linenumber), ' ',line])
+            self.write(newline)
+        else:
+            self.write(line)


### PR DESCRIPTION
Some NC controllers require line numbers to be added to every line of G-Code in order to process the code.

This pull request adds an option to the General Settings page that allows this feature to be turned on or off.  Its value can be saved and reloaded along with all other settings on the General Settings page.

This setting defaults to off (to preserve traditional behavior).  Defaulting off would be better for most people as some CNC controllers either don't have the processing power or bandwidth to handle the extra data.  This can lead to momentary pauses in the machine's movements while running the code as the tool ends up waiting for the controller.  These pauses can appear as stuttering.

However, some CNC controllers require line numbers to have Line Numbers.  For example, some older Fadal CNC controllers required this.  If they are not present, they will try to add their own.  But if too many consecutive lines without line numbers are found the controller will fault out as it line numbering sub routine appears to overflows.